### PR TITLE
Make trend fields optional

### DIFF
--- a/src/main/kotlin/netatmo/NetatmoWeatherResponse.kt
+++ b/src/main/kotlin/netatmo/NetatmoWeatherResponse.kt
@@ -39,8 +39,8 @@ data class NetatmoWeatherResponse(
                 val date_min_temp: Int,
                 val max_temp: Double,
                 val min_temp: Double,
-                val pressure_trend: String,
-                val temp_trend: String,
+                val pressure_trend: String?,
+                val temp_trend: String?,
                 val time_utc: Int
             )
 
@@ -66,7 +66,7 @@ data class NetatmoWeatherResponse(
                     val date_min_temp: Int,
                     val max_temp: Double,
                     val min_temp: Double,
-                    val temp_trend: String,
+                    val temp_trend: String?,
                     val time_utc: Int
                 )
             }


### PR DESCRIPTION
They will not be set after Netatmo has just been reconnected (which I had to to because it ran out of battery)